### PR TITLE
Fix #966: Search click handler on spans

### DIFF
--- a/src/templates/advance-search-template.js
+++ b/src/templates/advance-search-template.js
@@ -59,9 +59,9 @@ export default function searchByPropertiesModalTemplate() {
           }
         }"
       > 
-        <span class="upper bold-text method-fg ${path.method}">${path.method}</span> 
-        <span>${path.path}</span>
-        <span class="regular-font gray-text">${path.summary}</span>
+        <span data-content-id='${path.elementId}' class="upper bold-text method-fg ${path.method}">${path.method}</span> 
+        <span data-content-id='${path.elementId}'>${path.path}</span>
+        <span data-content-id='${path.elementId}' class="regular-font gray-text">${path.summary}</span>
       </div>
     `)
     }


### PR DESCRIPTION
Fixes an issue  with search where clicking on endpoint path/method is not scrolling due to event handler checking on event.target.contentId attribute

    if (!navEl.dataset.contentId) {
      return;
    }

This fix makes sure when clicking on any child element to pass the proper data-content-id within the event.